### PR TITLE
Fix `@Observable` property writes skipped when new value is == old value

### DIFF
--- a/Sources/SkipModel/Observed.swift
+++ b/Sources/SkipModel/Observed.swift
@@ -4,6 +4,7 @@
 
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.referentialEqualityPolicy
 
 /// We model properties of `@Observable` types as if they had this synthetic `@Observed` property wrapper.
 /// Like `Published`, it uses `MutableState` to tie into Compose's observation system.
@@ -48,7 +49,7 @@ public final class Observed<Value>: StateTracker {
     public func trackState() {
         // Once we create our internal MutableState, reads and writes will be tracked by Compose
         if projectedValue == nil {
-            projectedValue = mutableStateOf(_wrappedValue)
+            projectedValue = mutableStateOf(_wrappedValue, referentialEqualityPolicy())
         }
     }
 }


### PR DESCRIPTION
Compose `mutableStateOf` uses structural equality by default, so assigning a new dictionary (or other collection) to an `@Observable` property was ignored when `Equatable` said nothing changed.

Now, we use referential equality, so assignment always updates the backing state.

Fixes #24

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Tested using https://github.com/skiptools/skipapp-showcase/pull/110
